### PR TITLE
Implement a setup() function to avoid a warning.

### DIFF
--- a/sphinx_copybutton/__init__.py
+++ b/sphinx_copybutton/__init__.py
@@ -28,3 +28,4 @@ def setup(app):
     app.add_javascript(clipboard_js_url)
     app.add_javascript(pop_js_url)
     app.add_javascript(boot_js_url)
+    return {"version": __version__}


### PR DESCRIPTION
The warning is:

```
extension 'sphinx_copybutton' has no setup() function;
is it really a Sphinx extension module?
```

which comes from:

https://github.com/sphinx-doc/sphinx/blob/4165c8dd62433ac70227f607bb77a36c281b4ed9/sphinx/registry.py#L478-L479