### PR TITLE
updating svg path, docs, and circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2
+jobs:
+  # Define a "build_docs" job to be run with Circle
+  build_docs:
+    # This is the base environment that Circle will use
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      # Get our data and merge with upstream
+      - run: sudo apt-get update
+      - checkout
+      # Update our path
+      - run: echo "export PATH=~/.local/bin:$PATH" >> $BASH_ENV
+      # Restore cached files to speed things up
+      - restore_cache:
+          keys:
+            - cache-pip
+      # Install the packages needed to build our documentation
+      # This will depend on your particular package!
+      - run: pip install --user -r doc/requirements.txt
+      - run: pip install --user .
+      # Cache some files for a speedup in subsequent builds
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+      # Build the docs
+      - run:
+          name: Build docs to store
+          command: |
+            cd doc
+            make html
+      # Tell Circle to store the documentation output in a folder that we can access later
+      - store_artifacts:
+          path: doc/_build/html/
+          destination: html
+
+# Tell CircleCI to use this workflow when it builds the site
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build_docs

--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ extensions = [
 
 When you build your site, your code blocks should now have little copy buttons to their
 right. Clicking the button will copy the code inside!
+
+## Customization
+
+If you'd like to customize the look of the copy buttons, you can over-write any of the
+CSS rules specified in the Sphinx-CopyButton CSS file ([link](sphinx_copybutton/_static/copybutton.css))

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -85,3 +85,9 @@ pull to your computer and install locally with ``pip``::
     pip install -e /path/to/sphinx_copybutton
 
 **Pull requests** and **Issues** are absolutely welcome!
+
+.. toctree::
+   :maxdepth: 1
+
+   second/second_page
+   

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,1 @@
 sphinx
-
-# Install ourselves
--e .

--- a/doc/second/second_page.rst
+++ b/doc/second/second_page.rst
@@ -1,0 +1,9 @@
+=============
+A deeper page
+=============
+
+To make sure that the images / svg still works!
+
+.. code-block:: python
+
+   e = mc^2

--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -4,8 +4,8 @@ a.copybtn {
     top: 0;
     right: 0;
     margin: 5px;
-    width: 2em;
-    height: 2em;
+    width: 1em;
+    height: 1em;
     padding: 0 4px 2px;
   }
 

--- a/sphinx_copybutton/_static/copybutton.js
+++ b/sphinx_copybutton/_static/copybutton.js
@@ -18,7 +18,7 @@ const codeCellId = index => `codecell${index}`
 
 const clipboardButton = id =>
   `<a class="btn copybtn o-tooltip--left" data-tooltip="Copy" data-clipboard-target="#${id}">
-    <img src="_static/copy-button.svg" alt="Copy to clipboard">
+    <img src="/_static/copy-button.svg" alt="Copy to clipboard">
   </a>`
 
 // Clears selected text since ClipboardJS will select the text when copying

--- a/sphinx_copybutton/_static/copybutton.js
+++ b/sphinx_copybutton/_static/copybutton.js
@@ -18,7 +18,7 @@ const codeCellId = index => `codecell${index}`
 
 const clipboardButton = id =>
   `<a class="btn copybtn o-tooltip--left" data-tooltip="Copy" data-clipboard-target="#${id}">
-    <img src="/_static/copy-button.svg" alt="Copy to clipboard">
+    <img src="https://gitcdn.xyz/repo/choldgraf/sphinx-copybutton/master/sphinx_copybutton/_static/copy-button.svg" alt="Copy to clipboard">
   </a>`
 
 // Clears selected text since ClipboardJS will select the text when copying


### PR DESCRIPTION
closes #8 

The only way I could figure how to get the SVG to load properly was to use the github CDN, since otherwise I'm not sure how to determine the relative path to the site root (since it may be a part of a subdirectory on a site)