### PR TITLE
removing .btn class

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,6 +74,7 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 #
 html_theme = 'alabaster'
+# html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/sphinx_copybutton/_static/copybutton.js
+++ b/sphinx_copybutton/_static/copybutton.js
@@ -17,7 +17,7 @@ const runWhenDOMLoaded = cb => {
 const codeCellId = index => `codecell${index}`
 
 const clipboardButton = id =>
-  `<a class="btn copybtn o-tooltip--left" data-tooltip="Copy" data-clipboard-target="#${id}">
+  `<a class="copybtn o-tooltip--left" data-tooltip="Copy" data-clipboard-target="#${id}">
     <img src="https://gitcdn.xyz/repo/choldgraf/sphinx-copybutton/master/sphinx_copybutton/_static/copy-button.svg" alt="Copy to clipboard">
   </a>`
 


### PR DESCRIPTION
I believe this class is what messed up the viz in the sphinx_read_the_docs theme.

I think it closes #11 