### PR TITLE
Slighly offset the button from top and right

### DIFF
--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -1,8 +1,8 @@
 /* Copy buttons */
 a.copybtn {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 2px;
+    right: 2px;
     width: 1em;
     height: 1em;
     padding: .3em;


### PR DESCRIPTION
With the current CSS, the button is aligned at the very top and right of code blocks. That way, it covers the border of code blocks in some of the builtin themes.

See e.g. https://matplotlib.org/devdocs/gallery/images_contours_and_fields/contourf_demo.html or http://pangeo.io/setup_guides/hpc.html

While you cannot make it right for every possible theme, the defaults should play nicely with the builtin sphinx themes.

This PR slightly offsets the button.

Before:
![image](https://user-images.githubusercontent.com/2836374/50424724-5a3c4b80-0869-11e9-8349-06c5d7b39a32.png)

After:
![image](https://user-images.githubusercontent.com/2836374/50424731-77711a00-0869-11e9-903d-4aaf37ed7b16.png)
