### PR TITLE
Include LICENSE and _static data in generated tarball.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     package_data={'sphinx_copybutton': ['_static/copybutton.css',
                                         '_static/copybutton.js',
                                         '_static/copy-button.svg']},
-    include_package_data=True,
     install_requires=["flit", "setuptools", "wheel", "sphinx"],
     classifiers=["License :: OSI Approved :: MIT License"]
 )


### PR DESCRIPTION
Use the license_file option in setup.cfg to tell setuptools where to find the license.

Remove the include_package_data option which seems to prevent package_data being used (include_package_data needs the data files to be specified in MANIFEST.in).

Fixes #40.