### PR TITLE
Use MANIFEST.in to include doc/ directory in source archive.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft doc/


### PR DESCRIPTION
When running `python setup.py sdist`, the resulting tarball has the doc/ folder in it.