### PR TITLE
CSS: Remove padding from copybtn

### DIFF
--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -13,6 +13,10 @@ div.highlight  {
     position: relative;
 }
 
+a.copybtn > img {
+    vertical-align: top;
+}
+
 .highlight:hover .copybtn {
 	opacity: 1;
 }

--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -1,11 +1,10 @@
 /* Copy buttons */
 a.copybtn {
     position: absolute;
-    top: 2px;
-    right: 2px;
+    top: .2em;
+    right: .2em;
     width: 1em;
     height: 1em;
-    padding: .1em;
 	opacity: .3;
 	transition: opacity 0.5s;
 }


### PR DESCRIPTION
This is an attempt to make the appearance of the button more similar between themes.

This is an example with the "alabaster" theme: https://3-229129726-gh.circle-artifacts.com/0/html/index.html

And this is how it looks with the "readthedocs" theme: https://2-229129726-gh.circle-artifacts.com/0/html/index.html

And, for comparison, this is how it would look with the "readthedocs" theme *before* this PR: https://4-229129726-gh.circle-artifacts.com/0/html/index.html