### PR TITLE
Add clipboard.js as git submodule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       # Get our data and merge with upstream
       - run: sudo apt-get update
       - checkout
+      - run: git submodule update --init
       # Update our path
       - run: echo "export PATH=~/.local/bin:$PATH" >> $BASH_ENV
       # Restore cached files to speed things up

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "clipboard.js"]
+	path = clipboard.js
+	url = https://github.com/zenorocha/clipboard.js.git

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,10 +8,6 @@ To create a new release of Sphinx-Copybutton, you need to do these things:
 1. Ensure that you have push access to the [Sphinx-Copybutton pypi repository](https://pypi.org/project/sphinx-copybutton/)
 2. Install [the twine package](https://twine.readthedocs.io/en/latest/). This is a package that helps you
    bundle and push new Python package distributions to pip.
-3. Make sure you have checked out the `clipboard.js` submodule.  If not, run
-   ```
-   git submodule update --init
-   ```
 
 ## To create the release
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,10 @@ To create a new release of Sphinx-Copybutton, you need to do these things:
 1. Ensure that you have push access to the [Sphinx-Copybutton pypi repository](https://pypi.org/project/sphinx-copybutton/)
 2. Install [the twine package](https://twine.readthedocs.io/en/latest/). This is a package that helps you
    bundle and push new Python package distributions to pip.
+3. Make sure you have checked out the `clipboard.js` submodule.  If not, run
+   ```
+   git submodule update --init
+   ```
 
 ## To create the release
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@ from setuptools import setup, find_packages
 from sphinx_copybutton import __version__
 
 if (os.path.isdir('clipboard.js') and
+        not os.path.islink('sphinx_copybutton/_static/clipboard.min.js')):
+    raise SystemExit("Error: Support for symbolic links is required")
+
+if (os.path.isdir('clipboard.js') and
         not os.path.isfile('clipboard.js/dist/clipboard.min.js')):
     raise SystemExit(
         """Error: clipboard.js submodule not available, run

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     packages=find_packages(),
     package_data={'sphinx_copybutton': ['_static/copybutton.css',
                                         '_static/copybutton.js',
-                                        '_static/copy-button.svg']},
+                                        '_static/copy-button.svg',
+                                        '_static/clipboard.min.js']},
     install_requires=["flit", "setuptools", "wheel", "sphinx"],
     classifiers=["License :: OSI Approved :: MIT License"]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,15 @@
+import os
+
 from setuptools import setup, find_packages
 from sphinx_copybutton import __version__
+
+if (os.path.isdir('clipboard.js') and
+        not os.path.isfile('clipboard.js/dist/clipboard.min.js')):
+    raise SystemExit(
+        """Error: clipboard.js submodule not available, run
+
+        git submodule update --init
+        """)
 
 with open('./README.md', 'r') as ff:
     readme_text = ff.read()

--- a/sphinx_copybutton/__init__.py
+++ b/sphinx_copybutton/__init__.py
@@ -7,8 +7,6 @@ def scb_static_path(app):
     static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '_static'))
     app.config.html_static_path.append(static_path)
 
-clipboard_js_url = "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"
-
 def setup(app):
     print('Adding copy buttons to code blocks...')
     # Add our static path
@@ -16,7 +14,7 @@ def setup(app):
 
     # Add relevant code to headers
     app.add_stylesheet('copybutton.css')
-    app.add_javascript(clipboard_js_url)
+    app.add_javascript('clipboard.min.js')
     app.add_javascript("copybutton.js")
     return {"version": __version__,
             "parallel_read_safe": True,

--- a/sphinx_copybutton/_static/clipboard.min.js
+++ b/sphinx_copybutton/_static/clipboard.min.js
@@ -1,0 +1,1 @@
+../../clipboard.js/dist/clipboard.min.js


### PR DESCRIPTION
See #43.

This is the resulting HTML: https://11-229129726-gh.circle-artifacts.com/0/html/index.html

Since this did not cause an error message when the submodule was not checked out, I have added an error message in cbadffe890790762b806e566039aa32a4d6d9552.

This should work both from the Git repo and from an `sdist`.

I do *not* know, however, whether this works as intended on a platform that doesn't support symbolic links.

This is not a problem when *using* the `wheel` or `sdist`, but it *might* be a problem when *creating* the package on a system without symlink support.