### PR TITLE
adding text replace feature

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,9 @@ Sphinx-copybutton
    :alt: PyPi page
 
 Sphinx-copybutton does one thing: add little "copy" button to the right
-of your code blocks. That's it!
+of your code blocks. That's it! It is a lightweight wrapper around the
+excellent (and also lightweight) Javascript library
+`ClipboardJS <https://clipboardjs.com/>`.
 
 **Here's an example**
 
@@ -23,6 +25,18 @@ And here's a code block, note the copy button to the right!
 .. code-block:: bash
 
    copy me!
+
+By default, ``sphinx-copybutton`` will remove Python prompts from
+each line that begins with them. For example, try copying the text
+below:
+
+.. code-block:: python
+
+   >>> a = 2
+   >>> print(a)
+
+The text that ``sphinx-copybutton`` uses can be configured as well. See
+:ref:`configure_copy_text` for more information.
 
 If the code block overlaps to the right of the text area, you can just click
 the button to get the whole thing.
@@ -73,8 +87,23 @@ Customize the CSS
 To customize the display of the copy button, you can add your own CSS files
 that overwrite the CSS in the
 `sphinx-copybutton CSS rules <https://github.com/choldgraf/sphinx-copybutton/blob/master/_static/copybutton.css>`_.
-Just add these files to `_static` in your documentation folder, and it should
+Just add these files to ``_static`` in your documentation folder, and it should
 overwrite sphinx-copybutton's behavior.
+
+.. _configure_copy_text:
+
+Customize the text that is removed during copying
+-------------------------------------------------
+
+By default, ``sphinx-copybutton`` will remove Python prompts (">>> ") from
+the beginning of each line. To change the text that is removed (or to remove
+no text at all), add the following configuration to your ``conf.py`` file:
+
+.. code:: python
+
+    copybutton_skip_text
+
+Note that this text will only be removed from lines that *begin* with the text.
 
 Use a different copy button image
 ---------------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -101,7 +101,7 @@ no text at all), add the following configuration to your ``conf.py`` file:
 
 .. code:: python
 
-    copybutton_skip_text
+    copybutton_skip_text = "sometexttoskip"
 
 Note that this text will only be removed from lines that *begin* with the text.
 

--- a/sphinx_copybutton/__init__.py
+++ b/sphinx_copybutton/__init__.py
@@ -7,15 +7,23 @@ def scb_static_path(app):
     static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '_static'))
     app.config.html_static_path.append(static_path)
 
+def add_skip_text_js(app):
+    skip_text = app.config['copybutton_skip_text']
+    app.add_js_file(None, body="var copybuttonSkipText = '{}';".format(skip_text))
+
 def setup(app):
     print('Adding copy buttons to code blocks...')
     # Add our static path
     app.connect('builder-inited', scb_static_path)
+    app.connect('builder-inited', add_skip_text_js)
+
+    # configuration for this tool
+    app.add_config_value("copybutton_skip_text", ">>> ", "html")
 
     # Add relevant code to headers
     app.add_stylesheet('copybutton.css')
-    app.add_javascript('clipboard.min.js')
-    app.add_javascript("copybutton.js")
+    app.add_js_file('clipboard.min.js')
+    app.add_js_file("copybutton.js")
     return {"version": __version__,
             "parallel_read_safe": True,
             "parallel_write_safe": True}

--- a/sphinx_copybutton/_static/copybutton.js
+++ b/sphinx_copybutton/_static/copybutton.js
@@ -60,6 +60,19 @@ const temporarilyChangeTooltip = (el, newText) => {
   setTimeout(() => el.setAttribute('data-tooltip', oldText), 2000)
 }
 
+// Callback when a copy button is clicked. Will be passed the node that was clicked
+// should then grab the text and replace pieces of text that shouldn't be used in output
+var copyTargetText = (trigger) => {
+  var target = document.querySelector(trigger.attributes['data-clipboard-target'].value);
+  var textContent = target.textContent.split('\n');
+  textContent.forEach((line, index) => {
+    if (line.startsWith(copybuttonSkipText)) {
+      textContent[index] = line.slice(copybuttonSkipText.length)
+    }
+  });
+  return textContent.join('\n')
+}
+
 const addCopyButtonToCodeCells = () => {
   // If ClipboardJS hasn't loaded, wait a bit and try again. This
   // happens because we load ClipboardJS asynchronously.
@@ -68,6 +81,7 @@ const addCopyButtonToCodeCells = () => {
     return
   }
 
+  // Add copybuttons to all of our code cells
   const codeCells = document.querySelectorAll('div.highlight pre')
   codeCells.forEach((codeCell, index) => {
     const id = codeCellId(index)
@@ -81,7 +95,10 @@ const addCopyButtonToCodeCells = () => {
     codeCell.insertAdjacentHTML('afterend', clipboardButton(id))
   })
 
-  const clipboard = new ClipboardJS('.copybtn')
+  // Initialize with a callback so we can modify the text before copy
+  const clipboard = new ClipboardJS('.copybtn', {text: copyTargetText})
+
+  // Update UI with error/success messages
   clipboard.on('success', event => {
     clearSelection()
     temporarilyChangeTooltip(event.trigger, messages[locale]['copy_success'])


### PR DESCRIPTION
This adds the ability to **not copy** certain chunks of text from code cells. It's meant for when there are prompts included with a code cell that you don't want copied (e.g., `>>> `). It modifies the javascript callback so that it:

1. Grabs the target code cell text
2. Checks each line to see if it begins with the user-configured "skip" text
3. If so, removes that text from the beginning of each line before copying

closes #30 