### PR TITLE
Avoid a Sphinx warning: add_stylesheet -> add_css_file

### DIFF
--- a/sphinx_copybutton/__init__.py
+++ b/sphinx_copybutton/__init__.py
@@ -21,7 +21,7 @@ def setup(app):
     app.add_config_value("copybutton_skip_text", ">>> ", "html")
 
     # Add relevant code to headers
-    app.add_stylesheet('copybutton.css')
+    app.add_css_file('copybutton.css')
     app.add_js_file('clipboard.min.js')
     app.add_js_file("copybutton.js")
     return {"version": __version__,


### PR DESCRIPTION
This has already been done for `add_javascript()` -> `add_js_file()`, so there should be no change in compatible versions.