### PR TITLE
Merge pull request #53 from mgeier/remove-dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,5 @@ setup(
                                         '_static/copybutton.js',
                                         '_static/copy-button.svg',
                                         '_static/clipboard.min.js']},
-    install_requires=["flit", "setuptools", "wheel", "sphinx"],
     classifiers=["License :: OSI Approved :: MIT License"]
 )


### PR DESCRIPTION
Is `flit` really needed when installing with `pip`?

`setuptools` has already been imported further up in the file, so installing it now would be a bit late ...

I guess `wheel` is only needed when building `bdist_wheel`, but not for normal `pip` installing, right?

And I guess users will want Sphinx if they install this module, but I don't think it should be a formal dependency.

I'm not sure about the last point in the case where only a subset of Sphinx versions are supported, but this is not the case here anyway.