### PR TITLE
Fix problems with some themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # Docs
 _build/
+
+# VS code config
+.vscode

--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -15,6 +15,7 @@ div.highlight  {
 
 a.copybtn > img {
     vertical-align: top;
+    margin: 0;
 }
 
 .highlight:hover .copybtn {

--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -17,6 +17,9 @@ div.highlight  {
 a.copybtn > img {
     vertical-align: top;
     margin: 0;
+    top: 0;
+    left: 0;
+    position: absolute;
 }
 
 .highlight:hover .copybtn {

--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -6,7 +6,8 @@ a.copybtn {
     width: 1em;
     height: 1em;
 	opacity: .3;
-	transition: opacity 0.5s;
+    transition: opacity 0.5s;
+    border: none;
 }
 
 div.highlight  {

--- a/sphinx_copybutton/_static/copybutton.js
+++ b/sphinx_copybutton/_static/copybutton.js
@@ -65,9 +65,18 @@ const temporarilyChangeTooltip = (el, newText) => {
 var copyTargetText = (trigger) => {
   var target = document.querySelector(trigger.attributes['data-clipboard-target'].value);
   var textContent = target.textContent.split('\n');
-  if(copybuttonSkipText === undefined){
-    var copybuttonSkipText = "";
+  // Prevent breaking of the copy functionality, for themes which don't
+  // set copybuttonSkipText properly.
+  if(! ("copybuttonSkipText" in window)){
+    var copybuttonSkipText = ">>> ";
+    console.warn(`sphinx_copybutton:
+    The theme that was used to generate this document, does not support the setting for 'copybutton_skip_text',
+    which is why its default of '>>> ' was used.
+    Please tell the theme developers to include javascript files with the template tag 'js_tag' for sphinx>=1.8.
+    Example: https://github.com/readthedocs/sphinx_rtd_theme/blob/ab7d388448258a24f8f4fa96dccb69d24f571736/sphinx_rtd_theme/layout.html#L30
+    `);
   }
+
   textContent.forEach((line, index) => {
     if (line.startsWith(copybuttonSkipText)) {
       textContent[index] = line.slice(copybuttonSkipText.length)

--- a/sphinx_copybutton/_static/copybutton.js
+++ b/sphinx_copybutton/_static/copybutton.js
@@ -65,6 +65,9 @@ const temporarilyChangeTooltip = (el, newText) => {
 var copyTargetText = (trigger) => {
   var target = document.querySelector(trigger.attributes['data-clipboard-target'].value);
   var textContent = target.textContent.split('\n');
+  if(copybuttonSkipText === undefined){
+    var copybuttonSkipText = "";
+  }
   textContent.forEach((line, index) => {
     if (line.startsWith(copybuttonSkipText)) {
       textContent[index] = line.slice(copybuttonSkipText.length)


### PR DESCRIPTION
This fixes some issues with some specific themes ([see](https://github.com/spatialaudio/nbsphinx/issues/376)).

Some problems are a result of css rules being overwritten by theme rules (astropy-theme, py3doc-enhanced-theme, typlog-theme), others are a result of an old way (julia-theme, pytorch-theme, itcase-theme, pyviz-theme) to include additional javascript files in a theme.

#### Details concerning javascript issues
The old way to include javascript files (`<script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>`) does not support a [missing file name](https://github.com/choldgraf/sphinx-copybutton/blob/7ab883110a02caa88dc025052f1154cae03af2fa/sphinx_copybutton/__init__.py#L12) so the browser tries to fetch a file `None`, which leaves `copybuttonSkipText` as undefined and breaks the copy functionality. If a theme uses `js_tag` to include javascript files for `sphinx>=1.8` it works fine (maybe `sphinx>=1.8` should also be a minimal requirement for this package?).

If a theme doesn't have the following part (itcase-theme, pyviz-theme):

```html
<script type="text/javascript">
        var DOCUMENTATION_OPTIONS = {
            URL_ROOT:'{{ url_root }}',
            VERSION:'{{ release|e }}',
            COLLAPSE_INDEX:false,
            FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
            HAS_SOURCE:  {{ has_source|lower }},
            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
        };
</script>
```
`copybutton.js` does throw the following error `copybutton.js:105 Uncaught ReferenceError: DOCUMENTATION_OPTIONS is not defined` in the console (problem with [` clipboardButton`](https://github.com/choldgraf/sphinx-copybutton/blob/7ab883110a02caa88dc025052f1154cae03af2fa/sphinx_copybutton/_static/copybutton.js#L91)) and even the icons aren't generated, due to early breaking.

IMHO this should be mentioned in the docs, maybe in a topic like `theme support/requirements`, so theme creators have a reference , if they want to support `sphinx-copybutton`
