### PR TITLE
Remove the last newline from the copied text

### DIFF
--- a/sphinx_copybutton/_static/copybutton.js
+++ b/sphinx_copybutton/_static/copybutton.js
@@ -70,7 +70,7 @@ var copyTargetText = (trigger) => {
       textContent[index] = line.slice(copybuttonSkipText.length)
     }
   });
-  return textContent.join('\n')
+  return textContent.slice(0, -1).join('\n') + textContent.slice(-1)
 }
 
 const addCopyButtonToCodeCells = () => {


### PR DESCRIPTION
Adding a newline at the end of the copied content is a bad UX when pasting to a Bash prompt (for example) as it runs the command before the user can edit it.

This PR removes the new line from the end of the content.

Fix #56 