### PR TITLE
Use innerText instead of textContent

### DIFF
--- a/sphinx_copybutton/_static/copybutton.js_t
+++ b/sphinx_copybutton/_static/copybutton.js_t
@@ -64,7 +64,7 @@ const temporarilyChangeTooltip = (el, newText) => {
 // should then grab the text and replace pieces of text that shouldn't be used in output
 var copyTargetText = (trigger) => {
   var target = document.querySelector(trigger.attributes['data-clipboard-target'].value);
-  var textContent = target.textContent.split('\n');
+  var textContent = target.innerText.split('\n');
   var copybuttonPromptText = '{{ copybutton_prompt_text }}'; // Inserted from config
   var onlyCopyPromptLines = {{ copybutton_only_copy_prompt_lines | lower }}; // Inserted from config
   var removePrompts = {{ copybutton_remove_prompts | lower }}; // Inserted from config


### PR DESCRIPTION
To avoid copying styles and scripts, this makes it work with the sphinx-prompt extension.

https://www.w3schools.com/jsref/prop_node_innertext.asp

I hacked it like this in my conf.py file for now:
```
copybutton_prompt_text = """>>> ';
textContent = target.innerText.split('\\n'); var dummy = '
"""
```