### PR TITLE
Make button un-selectable

### DIFF
--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -8,6 +8,7 @@ a.copybtn {
 	opacity: .3;
     transition: opacity 0.5s;
     border: none;
+    user-select: none;
 }
 
 div.highlight  {


### PR DESCRIPTION
When you do *not* use the copy button to copy text, but you select text in the old-fashioned way to copy it, you might also inadvertently select the button itself. This especially happens when selecting multiple adjacent code blocks.

This is a minor aesthetic glitch, but the real problem is that the `alt` text (typically "Copy to clipboard") ends up polluting the clipboard!